### PR TITLE
Save 2 bytes each in push and pop stack

### DIFF
--- a/c8c.c
+++ b/c8c.c
@@ -542,15 +542,13 @@ static void gfpush()
 {
     print("\tLD F,VE");
     print("\tLD [I],VE");
-    print("\tLD VF,0x03");
-    print("\tADD VE,VF");
+    print("\tADD VE,0x03");
 }
 
 // Generate frame pop.
 static void gfpop()
 {
-    print("\tLD VF,0x03");
-    print("\tSUB VE,VF");
+    print("\tSUB VE,0x03");
     print("\tLD VF,V%1X", v);
     print("\tLD F,VE");
     print("\tLD VE,[I]");

--- a/c8c.c
+++ b/c8c.c
@@ -548,7 +548,7 @@ static void gfpush()
 // Generate frame pop.
 static void gfpop()
 {
-    print("\tSUB VE,0x03");
+    print("\tADD VE,0xFD ; SUB VE, 0x03");
     print("\tLD VF,V%1X", v);
     print("\tLD F,VE");
     print("\tLD VE,[I]");


### PR DESCRIPTION
`ADD` supports a direct operand, so why not use it?

Also, what is the need for the 3 byte padding between stack frames?